### PR TITLE
Refactor clients.

### DIFF
--- a/examples/simpleReceive.ts
+++ b/examples/simpleReceive.ts
@@ -12,7 +12,7 @@ console.log("path: ", path);
 let ns: Namespace;
 async function main(): Promise<void> {
   ns = Namespace.createFromConnectionString(str);
-  const client = ns.createQueueClient(path, { receiveMode: ReceiveMode.peekLock, maxConcurrentCalls: 1 });
+  const client = ns.createQueueClient(path, { receiveMode: ReceiveMode.peekLock });
   const onMessage: OnMessage = async (brokeredMessage: Message) => {
     console.log(">>> Message: ", brokeredMessage);
     console.log("### Actual message:", brokeredMessage.body ? brokeredMessage.body.toString() : null);
@@ -32,7 +32,7 @@ async function main(): Promise<void> {
     console.log(">>>>> Error occurred: ", err);
   };
   //console.log(onMessage, onError);
-  client.receive(onMessage, onError, { autoComplete: true });
+  client.receive(onMessage, onError, { autoComplete: true, maxConcurrentCalls: 1 });
   // const msgs = await client.receiveBatch(10);
   // console.log(msgs);
   // giving some time for receiver setup to complete. This will make sure that the receiver can receive the newly sent

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -34,17 +34,7 @@ export abstract class Client {
     this.id = `${name}/${uuid()}`;
     this._context = ClientEntityContext.create(name, context);
   }
-  /**
-   * Provides the current type of the Client.
-   * @return {string} The entity type.
-   */
-  get type(): string {
-    let result = "Client";
-    if ((this as any).constructor && (this as any).constructor.name) {
-      result = (this as any).constructor.name;
-    }
-    return result;
-  }
+
   /**
    * Closes the client. This is an abstract method.
    */

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -9,7 +9,7 @@ export {
 export {
   AmqpError, Delivery, Dictionary, MessageProperties, MessageHeader
 } from "./rhea-promise";
-export { Message, ReceivedSBMessage, SBMessage } from "./message";
+export { Message, ReceivedSBMessage, ServiceBusMessage } from "./message";
 export { ReceiveHandler } from "./streamingReceiver";
 export { ReceiveMode, ReceiveOptions, OnError, OnMessage } from "./messageReceiver";
 export { TopicClient } from "./topicClient";

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -11,6 +11,8 @@ export {
 } from "./rhea-promise";
 export { Message, ReceivedSBMessage, SBMessage } from "./message";
 export { ReceiveHandler } from "./streamingReceiver";
-export { ReceiveOptions, OnError, OnMessage } from "./messageReceiver";
-export { QueueClientOptions, QueueClient, ReceiveMode } from "./queueClient";
+export { ReceiveMode, ReceiveOptions, OnError, OnMessage } from "./messageReceiver";
+export { TopicClient } from "./topicClient";
+export { SubscriptionClientOptions, SubscriptionClient } from "./subscriptionClient";
+export { QueueClientOptions, QueueClient } from "./queueClient";
 export { Namespace, NamespaceOptions } from "./namespace";

--- a/lib/message.ts
+++ b/lib/message.ts
@@ -24,9 +24,9 @@ export interface DeadLetterOptions {
 
 /**
  * Describes the message to be sent to ServiceBus.
- * @interface SBMessage.
+ * @interface ServiceBusMessage.
  */
-export interface SBMessage {
+export interface ServiceBusMessage {
   /**
    * @property {any} body - The message body that needs to be sent or is received.
    */
@@ -133,9 +133,9 @@ export interface SBMessage {
   userProperties?: Dictionary<any>;
 }
 
-export namespace SBMessage {
+export namespace ServiceBusMessage {
 
-  export function validate(msg: SBMessage): void {
+  export function validate(msg: ServiceBusMessage): void {
     if (!msg) {
       throw new Error("msg cannot be null or undefined.");
     }
@@ -202,7 +202,7 @@ export namespace SBMessage {
     }
   }
 
-  export function toAmqpMessage(msg: SBMessage): AmqpMessage {
+  export function toAmqpMessage(msg: ServiceBusMessage): AmqpMessage {
     validate(msg);
     const amqpMsg: AmqpMessage = {
       body: msg.body,
@@ -230,15 +230,15 @@ export namespace SBMessage {
     if (msg.partitionKey) amqpMsg.message_annotations![Constants.partitionKey] = msg.partitionKey;
     if (msg.viaPartitionKey) amqpMsg.message_annotations![Constants.viaPartitionKey] = msg.viaPartitionKey;
     if (msg.scheduledEnqueueTimeUtc) amqpMsg.message_annotations![Constants.scheduledEnqueueTime] = msg.scheduledEnqueueTimeUtc;
-    debug("SBMessage to AmqpMessage: %O", amqpMsg);
+    debug("ServiceBusMessage to AmqpMessage: %O", amqpMsg);
     return amqpMsg;
   }
 
-  export function fromAmqpMessage(msg: AmqpMessage): SBMessage {
+  export function fromAmqpMessage(msg: AmqpMessage): ServiceBusMessage {
     if (!msg) {
       throw new Error("msg cannot be null or undefined.");
     }
-    const sbmsg: SBMessage = {
+    const sbmsg: ServiceBusMessage = {
       body: msg.body,
     };
 
@@ -258,7 +258,7 @@ export namespace SBMessage {
       if (msg.message_annotations[Constants.viaPartitionKey]) sbmsg.viaPartitionKey = msg.message_annotations[Constants.viaPartitionKey];
       if (msg.message_annotations[Constants.scheduledEnqueueTime]) sbmsg.scheduledEnqueueTimeUtc = msg.message_annotations[Constants.scheduledEnqueueTime];
     }
-    debug("AmqpMessage to SBMessage: %O", sbmsg);
+    debug("AmqpMessage to ServiceBusMessage: %O", sbmsg);
     return sbmsg;
   }
 }
@@ -267,7 +267,7 @@ export namespace SBMessage {
  * Describes the message received from ServiceBus.
  * @class ReceivedSBMessage
  */
-export interface ReceivedSBMessage extends SBMessage {
+export interface ReceivedSBMessage extends ServiceBusMessage {
   /**
    * @property {string} [lockToken] The lock token for the current message. The lock token is a
    * reference to the lock that is being held by the broker in `ReceiveMode.PeekLock` mode. Locks
@@ -364,7 +364,7 @@ export interface ReceivedSBMessage extends SBMessage {
 export namespace ReceivedSBMessage {
 
   export function validate(msg: ReceivedSBMessage): void {
-    SBMessage.validate(msg);
+    ServiceBusMessage.validate(msg);
     if (msg.lockToken && typeof msg.lockToken !== "string") {
       throw new Error("contentType must be of type string.");
     }
@@ -399,7 +399,7 @@ export namespace ReceivedSBMessage {
 
   export function toAmqpMessage(msg: ReceivedSBMessage): AmqpMessage {
     ReceivedSBMessage.validate(msg);
-    const amqpMsg: AmqpMessage = SBMessage.toAmqpMessage(msg);
+    const amqpMsg: AmqpMessage = ServiceBusMessage.toAmqpMessage(msg);
     if (msg.deliveryCount) amqpMsg.delivery_count = msg.deliveryCount;
     if (!amqpMsg.message_annotations) amqpMsg.message_annotations = {};
     if (msg.deadLetterSource) amqpMsg.message_annotations[Constants.deadLetterSource] = msg.deadLetterSource;
@@ -412,7 +412,7 @@ export namespace ReceivedSBMessage {
   }
 
   export function fromAmqpMessage(msg: AmqpMessage, delivery: Delivery): ReceivedSBMessage {
-    const sbmsg: SBMessage = SBMessage.fromAmqpMessage(msg);
+    const sbmsg: ServiceBusMessage = ServiceBusMessage.fromAmqpMessage(msg);
     const props: any = {};
     if (msg.message_annotations) {
       if (msg.message_annotations[Constants.deadLetterSource]) props.deadLetterSource = msg.message_annotations[Constants.deadLetterSource];

--- a/lib/messageReceiver.ts
+++ b/lib/messageReceiver.ts
@@ -6,9 +6,26 @@ import { LinkEntity } from "./linkEntity";
 import { ClientEntityContext } from "./clientEntityContext";
 import { MessagingError, translate } from "./amqp-common";
 import { Receiver, OnAmqpEvent, EventContext, ReceiverOptions } from "./rhea-promise";
-import { ReceiveMode, Message } from ".";
+import { Message } from ".";
 
 const debug = debugModule("azure:service-bus:receiver");
+
+/**
+ * The mode in which messages should be received
+ */
+export enum ReceiveMode {
+  /**
+   * Peek the message and lock it until it is settled or times out.
+   * @type {Number}
+   */
+  peekLock = 1,
+
+  /**
+   * Remove the message from the service bus upon delivery.
+   * @type {Number}
+   */
+  receiveAndDelete = 2
+}
 
 export enum ReceiverType {
   batching = "batching",

--- a/lib/messageSender.ts
+++ b/lib/messageSender.ts
@@ -10,7 +10,7 @@ import {
   message
 } from "./rhea-promise";
 import { defaultLock, Func, retry, translate, AmqpMessage } from "./amqp-common";
-import { SBMessage } from "./message";
+import { ServiceBusMessage } from "./message";
 
 const debug = debugModule("azure:service-bus:sender");
 
@@ -70,7 +70,7 @@ export class MessageSender extends LinkEntity {
    * @param {any} data Message to send.  Will be sent as UTF8-encoded JSON string.
    * @returns {Promise<Delivery>} Promise<Delivery>
    */
-  async send(data: SBMessage): Promise<Delivery> {
+  async send(data: ServiceBusMessage): Promise<Delivery> {
     try {
       if (!data || (data && typeof data !== "object")) {
         throw new Error("data is required and it must be of type object.");
@@ -81,7 +81,7 @@ export class MessageSender extends LinkEntity {
           "possibly the connection.", this.senderLock);
         await defaultLock.acquire(this.senderLock, () => { return this._init(); });
       }
-      const message = SBMessage.toAmqpMessage(data);
+      const message = ServiceBusMessage.toAmqpMessage(data);
       message.body = this._context.namespace.dataTransformer.encode(data.body);
       return await this._trySend(message);
     } catch (err) {
@@ -98,7 +98,7 @@ export class MessageSender extends LinkEntity {
    * Batch message.
    * @return {Promise<Delivery>} Promise<Delivery>
    */
-  async sendBatch(datas: SBMessage[]): Promise<Delivery> {
+  async sendBatch(datas: ServiceBusMessage[]): Promise<Delivery> {
     try {
       if (!datas || (datas && !Array.isArray(datas))) {
         throw new Error("data is required and it must be an Array.");
@@ -114,7 +114,7 @@ export class MessageSender extends LinkEntity {
       const messages: AmqpMessage[] = [];
       // Convert Message to AmqpMessage.
       for (let i = 0; i < datas.length; i++) {
-        const message = SBMessage.toAmqpMessage(datas[i]);
+        const message = ServiceBusMessage.toAmqpMessage(datas[i]);
         message.body = this._context.namespace.dataTransformer.encode(datas[i].body);
         messages[i] = message;
       }
@@ -157,7 +157,7 @@ export class MessageSender extends LinkEntity {
    * @param message The message to be sent to ServiceBus.
    * @return {Promise<Delivery>} Promise<Delivery>
    */
-  private _trySend(message: SBMessage, tag?: any, format?: number): Promise<Delivery> {
+  private _trySend(message: ServiceBusMessage, tag?: any, format?: number): Promise<Delivery> {
     const sendEventPromise = new Promise<Delivery>((resolve, reject) => {
       debug("[%s] Sender '%s', credit: %d available: %d", this._context.namespace.connectionId,
         this.id, this._sender!.credit, this._sender!.session.outgoing.available());

--- a/lib/namespace.ts
+++ b/lib/namespace.ts
@@ -94,6 +94,12 @@ export class Namespace {
         for (const client of Object.values(this._context.clients)) {
           await client.close();
         }
+
+        // Close management sessions
+        for (const client of Object.values(this._context.clients)) {
+          await (client as any)._context.managementSession!.close();
+        }
+
         // Close the cbs session
         if (this._context.cbsSession) {
           await this._context.cbsSession!.close();

--- a/lib/namespace.ts
+++ b/lib/namespace.ts
@@ -10,7 +10,6 @@ import { QueueClientOptions, QueueClient } from "./queueClient";
 import { TopicClient } from "./topicClient";
 import { ConnectionConfig, DataTransformer, TokenProvider, AadTokenProvider } from "./amqp-common";
 
-
 const debug = debugModule("azure:service-bus:namespace");
 
 export interface NamespaceOptions {
@@ -119,7 +118,7 @@ export class Namespace {
    * @returns {Namespace} - An instance of the Namespace.
    */
   static createFromConnectionString(connectionString: string, options?: NamespaceOptions): Namespace {
-    if (!connectionString || (connectionString && typeof connectionString !== "string")) {
+    if (!connectionString || typeof connectionString !== "string") {
       throw new Error("'connectionString' is a required parameter and must be of type: 'string'.");
     }
     const config = ConnectionConfig.create(connectionString);
@@ -140,16 +139,12 @@ export class Namespace {
     host: string,
     credentials: ApplicationTokenCredentials | UserTokenCredentials | DeviceTokenCredentials | MSITokenCredentials,
     options?: NamespaceOptions): Namespace {
-    if (!host || (host && typeof host !== "string")) {
+    if (!host || typeof host !== "string") {
       throw new Error("'host' is a required parameter and must be of type: 'string'.");
     }
 
-    if (!credentials ||
-      !(credentials instanceof ApplicationTokenCredentials ||
-        credentials instanceof UserTokenCredentials ||
-        credentials instanceof DeviceTokenCredentials ||
-        credentials instanceof MSITokenCredentials)) {
-      throw new Error("'credentials' is a required parameter and must be an instance of ApplicationTokenCredentials | UserTokenCredentials | DeviceTokenCredentials | MSITokenCredentials.");
+    if (!credentials) {
+      throw new Error("'credentials' is a required parameter..");
     }
 
     if (!host.endsWith("/")) host += "/";

--- a/lib/queueClient.ts
+++ b/lib/queueClient.ts
@@ -9,7 +9,7 @@ import { MessageSender } from "./messageSender";
 import { ReceiveMode, ReceiveOptions, OnError, OnMessage } from ".";
 import { StreamingReceiver, ReceiveHandler, MessageHandlerOptions } from "./streamingReceiver";
 import { BatchingReceiver } from "./batchingReceiver";
-import { Message, SBMessage } from "./message";
+import { Message, ServiceBusMessage } from "./message";
 import { Client } from "./client";
 
 const debug = debugModule("azure:service-bus:queue-client");
@@ -95,7 +95,7 @@ export class QueueClient extends Client {
    * @param {any} data  Message to send.  Will be sent as UTF8-encoded JSON string.
    * @returns {Promise<Delivery>} Promise<Delivery>
    */
-  async send(data: SBMessage): Promise<Delivery> {
+  async send(data: ServiceBusMessage): Promise<Delivery> {
     const sender = MessageSender.create(this._context);
     return await sender.send(data);
   }
@@ -109,7 +109,7 @@ export class QueueClient extends Client {
    *
    * @return {Promise<Delivery>} Promise<Delivery>
    */
-  async sendBatch(datas: SBMessage[]): Promise<Delivery> {
+  async sendBatch(datas: ServiceBusMessage[]): Promise<Delivery> {
     const sender = MessageSender.create(this._context);
     return await sender.sendBatch(datas);
   }

--- a/lib/queueClient.ts
+++ b/lib/queueClient.ts
@@ -24,13 +24,6 @@ export interface QueueClientOptions {
    * Default: ReceiveMode.peekLock
    */
   receiveMode?: ReceiveMode;
-  /**
-   * @property {number} [maxConcurrentCalls] The maximum number of messages that should be
-   * processed concurrently while in peek lock mode. Once this limit has been reached, more
-   * messages will not be received until messages currently being processed have been settled.
-   * Default: 1
-   */
-  maxConcurrentCalls?: number;
 }
 
 export class QueueClient extends Client {
@@ -39,12 +32,6 @@ export class QueueClient extends Client {
    * Default: ReceiveMode.peekLock
    */
   receiveMode: ReceiveMode;
-  /**
-   * @property {number} maxConcurrentCalls The maximum number of messages that should be
-   * processed concurrently while in peek lock mode. Once this limit has been reached, more
-   * messages will not be received until messages currently being processed have been settled.
-   */
-  maxConcurrentCalls: number;
 
   /**
    * Instantiates a client pointing to the ServiceBus Queue given by this configuration.
@@ -58,7 +45,6 @@ export class QueueClient extends Client {
     super(name, context);
     if (!options) options = {};
     this.receiveMode = options.receiveMode || ReceiveMode.peekLock;
-    this.maxConcurrentCalls = options.maxConcurrentCalls != undefined ? options.maxConcurrentCalls : 1;
   }
 
   /**
@@ -122,16 +108,16 @@ export class QueueClient extends Client {
    * @param {OnMessage} onMessage          The message handler to receive Message objects.
    * @param {OnError} onError              The error handler to receive an error that occurs
    * while receiving messages.
+   * @param {MessageHandlerOptions} [options]     Options for how you'd like to connect.
    *
    * @returns {ReceiveHandler} ReceiveHandler - An object that provides a mechanism to stop
    * receiving more messages.
    */
   receive(onMessage: OnMessage, onError: OnError, options?: MessageHandlerOptions): ReceiveHandler {
-    if (!this._context.streamingReceiver ||
-      (this._context.streamingReceiver && !this._context.streamingReceiver.isOpen())) {
+    if (!this._context.streamingReceiver || !this._context.streamingReceiver.isOpen()) {
       if (!options) options = {};
       const rcvOptions: ReceiveOptions = {
-        maxConcurrentCalls: this.maxConcurrentCalls,
+        maxConcurrentCalls: options.maxConcurrentCalls || 1,
         receiveMode: this.receiveMode,
         autoComplete: options.autoComplete
       };

--- a/lib/queueClient.ts
+++ b/lib/queueClient.ts
@@ -6,29 +6,13 @@ import { MessagingError } from "./amqp-common";
 import { Delivery } from "./rhea-promise";
 import { ConnectionContext } from "./connectionContext";
 import { MessageSender } from "./messageSender";
-import { ReceiveOptions, OnError, OnMessage } from ".";
+import { ReceiveMode, ReceiveOptions, OnError, OnMessage } from ".";
 import { StreamingReceiver, ReceiveHandler, MessageHandlerOptions } from "./streamingReceiver";
 import { BatchingReceiver } from "./batchingReceiver";
 import { Message, SBMessage } from "./message";
 import { Client } from "./client";
+
 const debug = debugModule("azure:service-bus:queue-client");
-
-/**
- * The mode in which messages should be received
- */
-export enum ReceiveMode {
-  /**
-   * Peek the message and lock it until it is settled or times out.
-   * @type {Number}
-   */
-  peekLock = 1,
-
-  /**
-   * Remove the message from the service bus upon delivery.
-   * @type {Number}
-   */
-  receiveAndDelete = 2
-}
 
 /**
  * Describes the options that can be provided while creating the QueueClient.

--- a/lib/queueClient.ts
+++ b/lib/queueClient.ts
@@ -61,8 +61,6 @@ export class QueueClient extends Client {
         if (this._context.streamingReceiver) {
           await this._context.streamingReceiver.close();
         }
-        // Close the management session
-        await this._context.managementSession!.close();
         debug("Closed the client '%s'.", this.id);
       }
     } catch (err) {

--- a/lib/streamingReceiver.ts
+++ b/lib/streamingReceiver.ts
@@ -58,6 +58,13 @@ export interface MessageHandlerOptions {
    * or while messages are received using receiveBatch(). Default: true.
    */
   autoComplete?: boolean;
+
+  /**
+   * @property {number} [maxConcurrentCalls] The maximum number of messages that should be
+   * processed concurrently while in peek lock mode. Once this limit has been reached, more
+   * messages will not be received until messages currently being processed have been settled.
+   */
+  maxConcurrentCalls?: number;
 }
 
 /**

--- a/lib/subscriptionClient.ts
+++ b/lib/subscriptionClient.ts
@@ -22,13 +22,6 @@ export interface SubscriptionClientOptions {
    * Default: ReceiveMode.peekLock
    */
   receiveMode?: ReceiveMode;
-  /**
-   * @property {number} [maxConcurrentCalls] he maximum number of messages that should be
-   * processed concurrently while in peek lock mode. Once this limit has been reached, more
-   * messages will not be received until messages currently being processed have been settled.
-   * Default: 1
-   */
-  maxConcurrentCalls?: number;
 }
 
 export class SubscriptionClient extends Client {
@@ -45,13 +38,6 @@ export class SubscriptionClient extends Client {
    * Default: ReceiveMode.peekLock
    */
   receiveMode: ReceiveMode;
-  /**
-   * @property {number} maxConcurrentCalls he maximum number of messages that should be
-   * processed concurrently while in peek lock mode. Once this limit has been reached, more
-   * messages will not be received until messages currently being processed have been settled.
-   * Default: 1
-   */
-  maxConcurrentCalls: number;
 
   /**
    * Instantiates a client pointing to the ServiceBus Subscription given by this configuration.
@@ -68,7 +54,6 @@ export class SubscriptionClient extends Client {
     this.topicPath = topicPath;
     this.subscriptionName = subscriptionName;
     this.receiveMode = options.receiveMode || ReceiveMode.peekLock;
-    this.maxConcurrentCalls = options.maxConcurrentCalls || 1;
   }
 
   /**
@@ -103,17 +88,16 @@ export class SubscriptionClient extends Client {
    * @param {OnMessage} onMessage          The message handler to receive Message objects.
    * @param {OnError} onError              The error handler to receive an error that occurs
    * while receiving messages.
-   * @param {ReceiveOptions} [options]     Options for how you'd like to connect.
+   * @param {MessageHandlerOptions} [options]     Options for how you'd like to connect.
    *
    * @returns {ReceiveHandler} ReceiveHandler - An object that provides a mechanism to stop
    * receiving more messages.
    */
   receive(onMessage: OnMessage, onError: OnError, options?: MessageHandlerOptions): ReceiveHandler {
-    if (!this._context.streamingReceiver ||
-      (this._context.streamingReceiver && !this._context.streamingReceiver.isOpen())) {
+    if (!this._context.streamingReceiver || !this._context.streamingReceiver.isOpen()) {
       if (!options) options = {};
       const rcvOptions: ReceiveOptions = {
-        maxConcurrentCalls: this.maxConcurrentCalls,
+        maxConcurrentCalls: options.maxConcurrentCalls || 1,
         receiveMode: this.receiveMode,
         autoComplete: options.autoComplete
       };

--- a/lib/subscriptionClient.ts
+++ b/lib/subscriptionClient.ts
@@ -67,8 +67,6 @@ export class SubscriptionClient extends Client {
         if (this._context.streamingReceiver) {
           await this._context.streamingReceiver.close();
         }
-        // Close the management session
-        await this._context.managementSession!.close();
         debug("Closed the subscription client '%s'.", this.id);
       }
     } catch (err) {

--- a/lib/subscriptionClient.ts
+++ b/lib/subscriptionClient.ts
@@ -4,29 +4,13 @@
 import * as debugModule from "debug";
 import { MessagingError } from "./amqp-common";
 import { ConnectionContext } from "./connectionContext";
-import { ReceiveOptions, OnError, OnMessage } from ".";
+import { ReceiveMode, ReceiveOptions, OnError, OnMessage } from ".";
 import { StreamingReceiver, ReceiveHandler, MessageHandlerOptions } from "./streamingReceiver";
 import { BatchingReceiver } from "./batchingReceiver";
 import { Message } from "./message";
 import { Client } from "./client";
+
 const debug = debugModule("azure:service-bus:subscription-client");
-
-/**
- * The mode in which messages should be received
- */
-export enum ReceiveMode {
-  /**
-   * Peek the message and lock it until it is settled or times out.
-   * @type {Number}
-   */
-  peekLock = 1,
-
-  /**
-   * Remove the message from the service bus upon delivery.
-   * @type {Number}
-   */
-  receiveAndDelete = 2
-}
 
 /**
  * Describes the options that can be provided while creating the SubscriptionClient.

--- a/lib/topicClient.ts
+++ b/lib/topicClient.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 import * as debugModule from "debug";
-import { Delivery } from "./rhea-promise";
 import { ConnectionContext } from "./connectionContext";
 import { MessageSender } from "./messageSender";
 import { ServiceBusMessage } from "./message";
@@ -35,8 +34,6 @@ export class TopicClient extends Client {
         if (this._context.sender) {
           await this._context.sender.close();
         }
-        // Close the management session
-        await this._context.managementSession!.close();
         debug("Closed the topic client '%s'.", this.id);
       }
     } catch (err) {
@@ -51,11 +48,13 @@ export class TopicClient extends Client {
    * Sends the given message to the ServiceBus Topic.
    *
    * @param {any} data  Message to send.  Will be sent as UTF8-encoded JSON string.
-   * @returns {Promise<Delivery>} Promise<Delivery>
+   * @returns {Promise<void>} Promise<void>
    */
-  async send(data: ServiceBusMessage): Promise<Delivery> {
+  async send(data: ServiceBusMessage): Promise<void> {
     const sender = MessageSender.create(this._context);
-    return await sender.send(data);
+    await sender.send(data);
+
+    return Promise.resolve();
   }
 
   /**
@@ -66,10 +65,12 @@ export class TopicClient extends Client {
    * @param {Array<Message>} datas  An array of Message objects to be sent in a Batch
    * message.
    *
-   * @return {Promise<Delivery>} Promise<Delivery>
+   * @return {Promise<void>} Promise<void>
    */
-  async sendBatch(datas: ServiceBusMessage[]): Promise<Delivery> {
+  async sendBatch(datas: ServiceBusMessage[]): Promise<void> {
     const sender = MessageSender.create(this._context);
-    return await sender.sendBatch(datas);
+    await sender.sendBatch(datas);
+
+    return Promise.resolve();
   }
 }

--- a/lib/topicClient.ts
+++ b/lib/topicClient.ts
@@ -7,10 +7,8 @@ import { ConnectionContext } from "./connectionContext";
 import { MessageSender } from "./messageSender";
 import { SBMessage } from "./message";
 import { Client } from "./client";
+
 const debug = debugModule("azure:service-bus:topic-client");
-
-
-
 
 export class TopicClient extends Client {
   /**

--- a/lib/topicClient.ts
+++ b/lib/topicClient.ts
@@ -5,7 +5,7 @@ import * as debugModule from "debug";
 import { Delivery } from "./rhea-promise";
 import { ConnectionContext } from "./connectionContext";
 import { MessageSender } from "./messageSender";
-import { SBMessage } from "./message";
+import { ServiceBusMessage } from "./message";
 import { Client } from "./client";
 
 const debug = debugModule("azure:service-bus:topic-client");
@@ -53,7 +53,7 @@ export class TopicClient extends Client {
    * @param {any} data  Message to send.  Will be sent as UTF8-encoded JSON string.
    * @returns {Promise<Delivery>} Promise<Delivery>
    */
-  async send(data: SBMessage): Promise<Delivery> {
+  async send(data: ServiceBusMessage): Promise<Delivery> {
     const sender = MessageSender.create(this._context);
     return await sender.send(data);
   }
@@ -68,7 +68,7 @@ export class TopicClient extends Client {
    *
    * @return {Promise<Delivery>} Promise<Delivery>
    */
-  async sendBatch(datas: SBMessage[]): Promise<Delivery> {
+  async sendBatch(datas: ServiceBusMessage[]): Promise<Delivery> {
     const sender = MessageSender.create(this._context);
     return await sender.sendBatch(datas);
   }


### PR DESCRIPTION
## Description
I'm excited about this library so this is an attempt to address some of the initial PR feedback found [here](https://github.com/Azure/azure-service-bus-node/pull/5). The changes in this PR are focused on refactoring the client code:
- Do not expose the client type https://github.com/Azure/azure-service-bus-node/pull/5#discussion-diff-200783043R41
- Rename `SBMessage` to `ServiceBusMessage` https://github.com/Azure/azure-service-bus-node/pull/5#discussion-diff-200786444R114
- Expose `TopicClient` and `SubscriptionClient` https://github.com/Azure/azure-service-bus-node/pull/5#discussion-diff-200782800R15
- Move `maxConcurrentCalls` options to receive function of clients https://github.com/Azure/azure-service-bus-node/pull/5#discussion-diff-198915495R16
- Move management session closing logic from clients to namespace https://github.com/Azure/azure-service-bus-node/pull/5#discussion-diff-200786869R97
- Addressed misc PR feedback on clients https://github.com/Azure/azure-service-bus-node/pull/5#discussion-diff-198915495R16, https://github.com/Azure/azure-service-bus-node/pull/5#discussion-diff-200787076R147, https://github.com/Azure/azure-service-bus-node/pull/5#discussion-diff-200790770R196, https://github.com/Azure/azure-service-bus-node/pull/5#discussion-diff-200786710R114, https://github.com/Azure/azure-service-bus-node/pull/5#discussion-diff-200784526R148

# References
- https://github.com/Azure/azure-service-bus-node/pull/5
